### PR TITLE
fixed bgpInfo bug with multiple AS

### DIFF
--- a/lib/whois.js
+++ b/lib/whois.js
@@ -776,22 +776,24 @@ const bgpInfo = async host => {
 
     // construct result
     let response_arr = response[0][0].split(' | ');
-    result.as              = response_arr[0];
+    result.as              = response_arr[0].split(' ');
     result.prefix          = response_arr[1];
     result.country_code    = response_arr[2];
     result.registry        = response_arr[3];
     result.allocation_date = response_arr[4];
 
-    // get 'AS Name'
-    bgpRequestHost = 'AS'.concat(result.as, '.', bgpAsServer);
-    response = await dns.resolve(bgpRequestHost, 'TXT');
-    if (
-        (response !== null) &&
-        (0 in response)     &&
-        (0 in response[0])
-    ) {
-        response_arr = response[0][0].split(' | ');
-        result.name = response_arr[4];
+  // get 'AS Name'
+    for (const as of result.as) {
+        bgpRequestHost = 'AS'.concat(as, '.', bgpAsServer);
+        response = await dns.resolve(bgpRequestHost, 'TXT');
+        if (
+            (response !== null) &&
+            (0 in response)     &&
+            (0 in response[0])
+        ) {
+            response_arr = response[0][0].split(' | ');
+            (result.name = result.name || []).push(response_arr[4]);
+        }
     }
 
     return result;


### PR DESCRIPTION
Previously:
A bgpInfo call would occasionally return the following error due to not correctly parsing a response containing multiple AS numbers:
```
{ Error: queryTxt ENOTFOUND ASXXXXX YYYYY.asn.cymru.com
    at QueryReqWrap.onresolve [as oncomplete] (internal/dns/promises.js:165:17)
  errno: 'ENOTFOUND',
  code: 'ENOTFOUND',
  syscall: 'queryTxt',
  hostname: 'ASXXXXX YYYYY.asn.cymru.com' }
```

Now:
bgpInfo correctly parses multiple AS numbers and returns arrays for both the as and name fields. Potentially breaking for clients who expect strings.
